### PR TITLE
Added packet.MarshalTo() and made packet.Marshal() faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author*
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Michael MacDonald](https://github.com/mjmac)
+* [Luke Curley](https://github.com/kixelated) *Performance*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/packet.go
+++ b/packet.go
@@ -7,7 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// TODO(@kixelated) Remove Header.PayloadOffset and Packet.Raw
+
 // Header represents an RTP packet header
+// NOTE: PayloadOffset is populated by Marshal/Unmarshal and should not be modified
 type Header struct {
 	Version          uint8
 	Padding          bool
@@ -24,6 +27,7 @@ type Header struct {
 }
 
 // Packet represents an RTP Packet
+// NOTE: Raw is populated by Marshal/Unmarshal and should not be modified
 type Packet struct {
 	Header
 	Raw     []byte
@@ -128,6 +132,7 @@ func (h *Header) Unmarshal(rawPacket []byte) error {
 		currOffset += len(h.ExtensionPayload)
 	}
 	h.PayloadOffset = currOffset
+
 	return nil
 }
 
@@ -142,8 +147,14 @@ func (p *Packet) Unmarshal(rawPacket []byte) error {
 	return nil
 }
 
-// Marshal returns a raw RTP header for the instance it is called upon
+// Marshal serializes the header into bytes.
 func (h *Header) Marshal() ([]byte, error) {
+	buf := make([]byte, 0, h.marshalSize())
+	return h.MarshalTo(buf)
+}
+
+// MarshalTo serializes the header and appends to the buffer.
+func (h *Header) MarshalTo(buf []byte) ([]byte, error) {
 	/*
 	 *  0                   1                   2                   3
 	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -159,61 +170,99 @@ func (h *Header) Marshal() ([]byte, error) {
 	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	 */
 
-	rawHeaderLength := 12 + (len(h.CSRC) * csrcLength)
-	if h.Extension {
-		rawHeaderLength += 4 + len(h.ExtensionPayload)
-	}
-	rawHeader := make([]byte, rawHeaderLength)
+	// Get the initial size of the buffer.
+	origLen := len(buf)
 
-	rawHeader[0] |= h.Version << versionShift
+	b0 := (h.Version << versionShift) | uint8(len(h.CSRC))
 	if h.Padding {
-		rawHeader[0] |= 1 << paddingShift
+		b0 |= 1 << paddingShift
 	}
-	if h.Extension {
-		rawHeader[0] |= 1 << extensionShift
-	}
-	rawHeader[0] |= uint8(len(h.CSRC))
 
+	if h.Extension {
+		b0 |= 1 << extensionShift
+	}
+
+	b1 := h.PayloadType
 	if h.Marker {
-		rawHeader[1] |= 1 << markerShift
-	}
-	rawHeader[1] |= h.PayloadType
-
-	binary.BigEndian.PutUint16(rawHeader[seqNumOffset:], h.SequenceNumber)
-	binary.BigEndian.PutUint32(rawHeader[timestampOffset:], h.Timestamp)
-	binary.BigEndian.PutUint32(rawHeader[ssrcOffset:], h.SSRC)
-
-	for i, csrc := range h.CSRC {
-		binary.BigEndian.PutUint32(rawHeader[csrcOffset+(i*csrcLength):], csrc)
+		b1 = 1 << markerShift
 	}
 
-	currOffset := csrcOffset + (len(h.CSRC) * csrcLength)
+	buf = append(buf,
+		b0,
+		b1,
+		byte(h.SequenceNumber>>8),
+		byte(h.SequenceNumber),
+		byte(h.Timestamp>>24),
+		byte(h.Timestamp>>16),
+		byte(h.Timestamp>>8),
+		byte(h.Timestamp),
+		byte(h.SSRC>>24),
+		byte(h.SSRC>>16),
+		byte(h.SSRC>>8),
+		byte(h.SSRC),
+	)
 
-	for i := range h.CSRC {
-		offset := csrcOffset + (i * csrcLength)
-		h.CSRC[i] = binary.BigEndian.Uint32(rawHeader[offset:])
+	for _, csrc := range h.CSRC {
+		buf = append(buf,
+			byte(csrc>>24),
+			byte(csrc>>16),
+			byte(csrc>>8),
+			byte(csrc),
+		)
 	}
 
 	if h.Extension {
-		binary.BigEndian.PutUint16(rawHeader[currOffset:], h.ExtensionProfile)
-		currOffset += 2
-		binary.BigEndian.PutUint16(rawHeader[currOffset:], uint16(len(h.ExtensionPayload))/4)
-		currOffset += 2
-		copy(rawHeader[currOffset:], h.ExtensionPayload)
+		extSize := len(h.ExtensionPayload) / 4
+
+		buf = append(buf,
+			byte(h.ExtensionProfile>>8),
+			byte(h.ExtensionProfile),
+			byte(extSize>>8),
+			byte(extSize),
+		)
+
+		buf = append(buf, h.ExtensionPayload...)
 	}
 
-	h.PayloadOffset = csrcOffset + (len(h.CSRC) * csrcLength)
-	return rawHeader, nil
+	// Calculate the size of the header by seeing how many bytes we're written.
+	// This should be the same as h.marshalSize()
+	h.PayloadOffset = len(buf) - origLen
+
+	return buf, nil
 }
 
-// Marshal returns a raw RTP packet for the instance it is called upon
+// marshalSize returns the size of the header once marshaled.
+func (h *Header) marshalSize() int {
+	// NOTE: Be careful to match the MarshalTo() method.
+	size := 12 + (len(h.CSRC) * csrcLength)
+
+	if h.Extension {
+		size += 4 + len(h.ExtensionPayload)
+	}
+
+	return size
+}
+
+// Marshal serializes the packet into bytes.
 func (p *Packet) Marshal() ([]byte, error) {
-	rawPacket, err := p.Header.Marshal()
+	buf := make([]byte, 0, p.marshalSize())
+	return p.MarshalTo(buf)
+}
+
+// MarshalTo serializes the packet and appends to the buffer.
+func (p *Packet) MarshalTo(buf []byte) ([]byte, error) {
+	buf, err := p.Header.MarshalTo(buf)
 	if err != nil {
 		return nil, err
 	}
 
-	rawPacket = append(rawPacket, p.Payload...)
-	p.Raw = rawPacket
-	return rawPacket, nil
+	buf = append(buf, p.Payload...)
+	p.Raw = buf
+
+	return buf, nil
+}
+
+// marshalSize returns the size of the packet once marshaled.
+func (p *Packet) marshalSize() int {
+	return p.Header.marshalSize() + len(p.Payload)
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -29,7 +29,6 @@ func TestBasic(t *testing.T) {
 			SSRC:             476325762,
 			CSRC:             []uint32{},
 		},
-
 		Payload: rawPkt[20:],
 		Raw:     rawPkt,
 	}
@@ -67,4 +66,51 @@ func TestExtension(t *testing.T) {
 		t.Fatal("Unmarshal did not error on packet with invalid extension length")
 	}
 
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	rawPkt := []byte{
+		0x90, 0x60, 0x69, 0x8f, 0xd9, 0xc2, 0x93, 0xda, 0x1c, 0x64,
+		0x27, 0x82, 0x00, 0x01, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x98, 0x36, 0xbe, 0x88, 0x9e,
+	}
+
+	p := &Packet{}
+	err := p.Unmarshal(rawPkt)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err = p.Marshal()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalTo(b *testing.B) {
+	rawPkt := []byte{
+		0x90, 0x60, 0x69, 0x8f, 0xd9, 0xc2, 0x93, 0xda, 0x1c, 0x64,
+		0x27, 0x82, 0x00, 0x01, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x98, 0x36, 0xbe, 0x88, 0x9e,
+	}
+
+	p := &Packet{}
+
+	err := p.Unmarshal(rawPkt)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	buf := make([]byte, 0, len(rawPkt))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		buf, err = p.MarshalTo(buf[:0])
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -22,7 +22,6 @@ func TestBasic(t *testing.T) {
 			ExtensionProfile: 1,
 			ExtensionPayload: []byte{0xFF, 0xFF, 0xFF, 0xFF},
 			Version:          2,
-			PayloadOffset:    20,
 			PayloadType:      96,
 			SequenceNumber:   27023,
 			Timestamp:        3653407706,
@@ -30,7 +29,6 @@ func TestBasic(t *testing.T) {
 			CSRC:             []uint32{},
 		},
 		Payload: rawPkt[20:],
-		Raw:     rawPkt,
 	}
 
 	if err := p.Unmarshal(rawPkt); err != nil {


### PR DESCRIPTION
`packet.MarshalTo()` allows the caller to potentially avoid allocations. The `packet.MarshalSize()` method exists to inform the caller the size of the buffer we're expecting in order to prevent allocations. 

I removed `packet.Header.PayloadOffset` because it can be computed with `packet.Header.MarshalSize()`. I would be fine with `packet.Header.PayloadOffset()` as a function, but I really don't like `Marshal` causing side-effects. It should write the current values, not mutate them.

Along those lines, I also removed `packet.Raw`. You can call `packet.Marshal()` if you want the raw data. There's probably some disorganized code that tried to optimize performance by using this variable but it's dangerous. You could `packet.Marshal()` and then change a parameter but `packet.Raw` wouldn't be updated.

I like this `rtp.Packet` implementation because it only exposes struct variables found in the spec. Micro-performance optimizations need to be done without polluting the API. `payload.Header.PayloadOffset` saves nanoseconds compared to computing the offset, at the cost of a more frail API.


```
BenchmarkMarshalToNew-8   	100000000	        13.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkMarshalNew-8   	30000000	        49.2 ns/op	      32 B/op	       1 allocs/op
BenchmarkMarshalOld-8   	20000000	        89.6 ns/op	      80 B/op	       2 allocs/op
```

As you can see, memory management is HUGE in Go. We see a 2x speed up by avoiding a reallocation, and another 3.5x speed up by avoiding allocating altogether.