### PR TITLE
Initialized as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author*
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Michael MacDonald](https://github.com/mjmac)
+* [Luke Curley](https://github.com/kixelated) *nothing tbh*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pions/rtp
+
+require github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/pions/rtp
-
-require github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/packet.go
+++ b/packet.go
@@ -3,8 +3,6 @@ package rtp
 import (
 	"encoding/binary"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 // Header represents an RTP packet header
@@ -70,7 +68,7 @@ func (p Packet) String() string {
 // Unmarshal parses the passed byte slice and stores the result in the Header this method is called upon
 func (h *Header) Unmarshal(rawPacket []byte) error {
 	if len(rawPacket) < headerLength {
-		return errors.Errorf("RTP header size insufficient; %d < %d", len(rawPacket), headerLength)
+		return fmt.Errorf("RTP header size insufficient; %d < %d", len(rawPacket), headerLength)
 	}
 
 	/*
@@ -102,7 +100,7 @@ func (h *Header) Unmarshal(rawPacket []byte) error {
 
 	currOffset := csrcOffset + (len(h.CSRC) * csrcLength)
 	if len(rawPacket) < currOffset {
-		return errors.Errorf("RTP header size insufficient; %d < %d", len(rawPacket), currOffset)
+		return fmt.Errorf("RTP header size insufficient; %d < %d", len(rawPacket), currOffset)
 	}
 
 	for i := range h.CSRC {
@@ -112,7 +110,7 @@ func (h *Header) Unmarshal(rawPacket []byte) error {
 
 	if h.Extension {
 		if len(rawPacket) < currOffset+4 {
-			return errors.Errorf("RTP header size insufficient for extension; %d < %d", len(rawPacket), currOffset)
+			return fmt.Errorf("RTP header size insufficient for extension; %d < %d", len(rawPacket), currOffset)
 		}
 
 		h.ExtensionProfile = binary.BigEndian.Uint16(rawPacket[currOffset:])
@@ -121,7 +119,7 @@ func (h *Header) Unmarshal(rawPacket []byte) error {
 		currOffset += 2
 
 		if len(rawPacket) < currOffset+extensionLength {
-			return errors.Errorf("RTP header size insufficient for extension length; %d < %d", len(rawPacket), currOffset+extensionLength)
+			return fmt.Errorf("RTP header size insufficient for extension length; %d < %d", len(rawPacket), currOffset+extensionLength)
 		}
 
 		h.ExtensionPayload = rawPacket[currOffset : currOffset+extensionLength]


### PR DESCRIPTION
Required to use go.mod's `replace` directive for local development.