### PR TITLE
Checks on VP8 codecs Unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Michael MacDonald](https://github.com/mjmac)
 * [Luke Curley](https://github.com/kixelated) *Performance*
+* [Antoine Baché](https://github.com/Antonito) *Fixed crashes*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/codecs/common_test.go
+++ b/codecs/common_test.go
@@ -2,19 +2,21 @@ package codecs
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCommon_Min(t *testing.T) {
-	assert := assert.New(t)
-
 	res := min(1, -1)
-	assert.Equal(res, -1, "-1 < 1")
+	if res != -1 {
+		t.Fatal("Error: -1 < 1")
+	}
 
 	res = min(1, 2)
-	assert.Equal(res, 1, "1 < 2")
+	if res != 1 {
+		t.Fatal("Error: 1 < 2")
+	}
 
 	res = min(3, 3)
-	assert.Equal(res, 3, "3 == 3")
+	if res != 3 {
+		t.Fatal("Error: 3 == 3")
+	}
 }

--- a/codecs/common_test.go
+++ b/codecs/common_test.go
@@ -1,0 +1,20 @@
+package codecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommon_Min(t *testing.T) {
+	assert := assert.New(t)
+
+	res := min(1, -1)
+	assert.Equal(res, -1, "-1 < 1")
+
+	res = min(1, 2)
+	assert.Equal(res, 1, "1 < 2")
+
+	res = min(3, 3)
+	assert.Equal(res, 3, "3 == 3")
+}

--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -1,6 +1,10 @@
 package codecs
 
-import "github.com/pions/rtp"
+import (
+	"fmt"
+
+	"github.com/pions/rtp"
+)
 
 // VP8Payloader payloads VP8 packets
 type VP8Payloader struct{}
@@ -78,6 +82,11 @@ type VP8Packet struct {
 // Unmarshal parses the passed byte slice and stores the result in the VP8Packet this method is called upon
 func (p *VP8Packet) Unmarshal(packet *rtp.Packet) ([]byte, error) {
 	payload := packet.Payload
+
+	// If lower than the required header size, malformed header
+	if len(payload) < 4 {
+		return nil, fmt.Errorf("empty payload")
+	}
 
 	payloadIndex := 0
 

--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -82,10 +82,10 @@ type VP8Packet struct {
 // Unmarshal parses the passed byte slice and stores the result in the VP8Packet this method is called upon
 func (p *VP8Packet) Unmarshal(packet *rtp.Packet) ([]byte, error) {
 	payload := packet.Payload
+	payloadLen := len(payload)
 
-	// If lower than the required header size, malformed header
-	if len(payload) < 4 {
-		return nil, fmt.Errorf("empty payload")
+	if payloadLen < 4 {
+		return nil, fmt.Errorf("Payload is not large enough to container header")
 	}
 
 	payloadIndex := 0
@@ -121,6 +121,9 @@ func (p *VP8Packet) Unmarshal(packet *rtp.Packet) ([]byte, error) {
 		payloadIndex++
 	}
 
+	if payloadIndex >= payloadLen {
+		return nil, fmt.Errorf("Payload is not large enough")
+	}
 	p.Payload = payload[payloadIndex:]
 	return p.Payload, nil
 }

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 
 	"github.com/pions/rtp"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestVP8Packet_Unmarshal(t *testing.T) {
-	assert := assert.New(t)
 	pck := VP8Packet{}
 
 	errSmallerThanHeaderLen := fmt.Errorf("Payload is not large enough to container header")
@@ -19,76 +17,120 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	raw, err := pck.Unmarshal(&rtp.Packet{
 		Payload: nil,
 	})
-	assert.Nil(raw, "Result should be nil in case of error")
-	assert.Equal(err, errSmallerThanHeaderLen, "Error shouldn't nil in case of error")
+	if raw != nil {
+		t.Fatal("Result should be nil in case of error")
+	}
+	if err == nil || err.Error() != errSmallerThanHeaderLen.Error() {
+		t.Fatal("Error should be:", errSmallerThanHeaderLen)
+	}
 
 	// Empty payload
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: nil,
 	})
-	assert.Nil(raw, "Result should be nil in case of error")
-	assert.Equal(err, errSmallerThanHeaderLen, "Error shouldn't nil in case of error")
+	if raw != nil {
+		t.Fatal("Result should be nil in case of error")
+	}
+	if err == nil || err.Error() != errSmallerThanHeaderLen.Error() {
+		t.Fatal("Error should be:", errSmallerThanHeaderLen)
+	}
 
 	// Payload smaller than header size
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x00, 0x11, 0x22},
 	})
-	assert.Nil(raw, "Result should be nil in case of error")
-	assert.Equal(err, errSmallerThanHeaderLen, "Error shouldn't nil in case of error")
+	if raw != nil {
+		t.Fatal("Result should be nil in case of error")
+	}
+	if err == nil || err.Error() != errSmallerThanHeaderLen.Error() {
+		t.Fatal("Error should be:", errSmallerThanHeaderLen)
+	}
 
 	// Normal payload
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90},
 	})
-	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
-	assert.Nil(err, "Error should be nil in case of success")
+	if raw == nil {
+		t.Fatal("Result shouldn't be nil in case of success")
+	}
+	if err != nil {
+		t.Fatal("Error should be nil in case of success")
+	}
 
 	// Header size, only X
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x80, 0x00, 0x00, 0x00},
 	})
-	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
-	assert.Nil(err, "Error should be nil in case of success")
+	if raw == nil {
+		t.Fatal("Result shouldn't be nil in case of success")
+	}
+	if err != nil {
+		t.Fatal("Error should be nil in case of success")
+	}
 
 	// Header size, X and I
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x80, 0x80, 0x00, 0x00},
 	})
-	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
-	assert.Nil(err, "Error should be nil in case of success")
+	if raw == nil {
+		t.Fatal("Result shouldn't be nil in case of success")
+	}
+	if err != nil {
+		t.Fatal("Error should be nil in case of success")
+	}
 
 	// Header size, X and I, PID 16bits
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x80, 0x80, 0x81, 0x00},
 	})
-	assert.Nil(raw, "Result should be nil in case of error")
-	assert.Equal(err, errPayloadTooSmall, "Error shouldn't nil in case of error")
+	if raw != nil {
+		t.Fatal("Result should be nil in case of error")
+	}
+	if err == nil || err.Error() != errPayloadTooSmall.Error() {
+		t.Fatal("Error should be:", errPayloadTooSmall)
+	}
 
 	// Header size, X and L
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x80, 0x40, 0x00, 0x00},
 	})
-	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
-	assert.Nil(err, "Error should be nil in case of success")
+	if raw == nil {
+		t.Fatal("Result shouldn't be nil in case of success")
+	}
+	if err != nil {
+		t.Fatal("Error should be nil in case of success")
+	}
 
 	// Header size, X and T
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x80, 0x20, 0x00, 0x00},
 	})
-	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
-	assert.Nil(err, "Error should be nil in case of success")
+	if raw == nil {
+		t.Fatal("Result shouldn't be nil in case of success")
+	}
+	if err != nil {
+		t.Fatal("Error should be nil in case of success")
+	}
 
 	// Header size, X and K
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0x80, 0x10, 0x00, 0x00},
 	})
-	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
-	assert.Nil(err, "Error should be nil in case of success")
+	if raw == nil {
+		t.Fatal("Result shouldn't be nil in case of success")
+	}
+	if err != nil {
+		t.Fatal("Error should be nil in case of success")
+	}
 
 	// Header size, all flags
 	raw, err = pck.Unmarshal(&rtp.Packet{
 		Payload: []byte{0xff, 0xff, 0x00, 0x00},
 	})
-	assert.Nil(raw, "Result should be nil in case of error")
-	assert.Equal(err, errPayloadTooSmall, "Error shouldn't nil in case of error")
+	if raw != nil {
+		t.Fatal("Result should be nil in case of error")
+	}
+	if err == nil || err.Error() != errPayloadTooSmall.Error() {
+		t.Fatal("Error should be:", errPayloadTooSmall)
+	}
 }

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -1,0 +1,94 @@
+package codecs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pions/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVP8Packet_Unmarshal(t *testing.T) {
+	assert := assert.New(t)
+	pck := VP8Packet{}
+
+	errSmallerThanHeaderLen := fmt.Errorf("Payload is not large enough to container header")
+	errPayloadTooSmall := fmt.Errorf("Payload is not large enough")
+
+	// Nil payload
+	raw, err := pck.Unmarshal(&rtp.Packet{
+		Payload: nil,
+	})
+	assert.Nil(raw, "Result should be nil in case of error")
+	assert.Equal(err, errSmallerThanHeaderLen, "Error shouldn't nil in case of error")
+
+	// Empty payload
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: nil,
+	})
+	assert.Nil(raw, "Result should be nil in case of error")
+	assert.Equal(err, errSmallerThanHeaderLen, "Error shouldn't nil in case of error")
+
+	// Payload smaller than header size
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x00, 0x11, 0x22},
+	})
+	assert.Nil(raw, "Result should be nil in case of error")
+	assert.Equal(err, errSmallerThanHeaderLen, "Error shouldn't nil in case of error")
+
+	// Normal payload
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90},
+	})
+	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
+	assert.Nil(err, "Error should be nil in case of success")
+
+	// Header size, only X
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x80, 0x00, 0x00, 0x00},
+	})
+	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
+	assert.Nil(err, "Error should be nil in case of success")
+
+	// Header size, X and I
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x80, 0x80, 0x00, 0x00},
+	})
+	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
+	assert.Nil(err, "Error should be nil in case of success")
+
+	// Header size, X and I, PID 16bits
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x80, 0x80, 0x81, 0x00},
+	})
+	assert.Nil(raw, "Result should be nil in case of error")
+	assert.Equal(err, errPayloadTooSmall, "Error shouldn't nil in case of error")
+
+	// Header size, X and L
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x80, 0x40, 0x00, 0x00},
+	})
+	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
+	assert.Nil(err, "Error should be nil in case of success")
+
+	// Header size, X and T
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x80, 0x20, 0x00, 0x00},
+	})
+	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
+	assert.Nil(err, "Error should be nil in case of success")
+
+	// Header size, X and K
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0x80, 0x10, 0x00, 0x00},
+	})
+	assert.NotNil(raw, "Result shouldn't be nil in case of succeess")
+	assert.Nil(err, "Error should be nil in case of success")
+
+	// Header size, all flags
+	raw, err = pck.Unmarshal(&rtp.Packet{
+		Payload: []byte{0xff, 0xff, 0x00, 0x00},
+	})
+	assert.Nil(raw, "Result should be nil in case of error")
+	assert.Equal(err, errPayloadTooSmall, "Error shouldn't nil in case of error")
+}


### PR DESCRIPTION
This is still a work in progress

We should implement basic checks on each Unmarshal function such has:
- the payload size is at least equal to the header's size
- check the PayloadType of the RTP packet
- additional checks to prevent any BoF
What do you think ? :)

Should fix https://github.com/pions/rtp/issues/1 and IVF unit tests on https://github.com/pions/webrtc/pull/445