### PR TITLE
add optional abs-send-time support to Packetizer

### DIFF
--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -6,7 +6,9 @@ import (
 
 func TestH264Payloader_Payload(t *testing.T) {
 	pck := H264Payloader{}
-	payload := []byte{0x90, 0x90, 0x90}
+	smallpayload := []byte{0x90, 0x90, 0x90}
+	multiplepayload := []byte{0x00, 0x00, 0x01, 0x90,
+		0x00, 0x00, 0x01, 0x90}
 
 	// Positive MTU, nil payload
 	res := pck.Payload(1, nil)
@@ -15,30 +17,41 @@ func TestH264Payloader_Payload(t *testing.T) {
 	}
 
 	// Negative MTU, small payload
-	res = pck.Payload(0, payload)
+	res = pck.Payload(0, smallpayload)
 	if len(res) != 0 {
 		t.Fatal("Generated payload should be empty")
 	}
 
 	// 0 MTU, small payload
-	res = pck.Payload(0, payload)
+	res = pck.Payload(0, smallpayload)
 	if len(res) != 0 {
 		t.Fatal("Generated payload should be empty")
 	}
 
 	// Positive MTU, small payload
-	res = pck.Payload(1, payload)
+	res = pck.Payload(1, smallpayload)
 	if len(res) != 0 {
 		t.Fatal("Generated payload should be empty")
 	}
 
 	// Positive MTU, small payload
-	res = pck.Payload(5, payload)
+	res = pck.Payload(5, smallpayload)
 	if len(res) != 1 {
 		t.Fatal("Generated payload shouldn't be empty")
 	}
-	if len(res[0]) != len(payload) {
+	if len(res[0]) != len(smallpayload) {
 		t.Fatal("Generated payload should be the same size as original payload size")
+	}
+
+	// Multiple NALU in a single payload
+	res = pck.Payload(5, multiplepayload)
+	if len(res) != 2 {
+		t.Fatal("2 nal units should be broken out")
+	}
+	for i := 0; i < 2; i++ {
+		if len(res[i]) != 1 {
+			t.Fatalf("Payload %d of 2 is packed incorrectly", i+1)
+		}
 	}
 
 	// Nalu type 9 or 12

--- a/codecs/opus_packet.go
+++ b/codecs/opus_packet.go
@@ -2,8 +2,6 @@ package codecs
 
 import (
 	"fmt"
-
-	"github.com/pions/rtp"
 )
 
 // OpusPayloader payloads Opus packets
@@ -26,13 +24,12 @@ type OpusPacket struct {
 }
 
 // Unmarshal parses the passed byte slice and stores the result in the OpusPacket this method is called upon
-func (p *OpusPacket) Unmarshal(packet *rtp.Packet) ([]byte, error) {
+func (p *OpusPacket) Unmarshal(packet []byte) ([]byte, error) {
 	if packet == nil {
 		return nil, fmt.Errorf("invalid nil packet")
 	}
-	if packet.Payload == nil {
+	if len(packet) == 0 {
 		return nil, fmt.Errorf("Payload is not large enough")
 	}
-	p.Payload = packet.Payload
-	return p.Payload, nil
+	return packet, nil
 }

--- a/codecs/opus_packet_test.go
+++ b/codecs/opus_packet_test.go
@@ -3,8 +3,6 @@ package codecs
 import (
 	"fmt"
 	"testing"
-
-	"github.com/pions/rtp"
 )
 
 func TestOpusPacket_Unmarshal(t *testing.T) {
@@ -23,9 +21,7 @@ func TestOpusPacket_Unmarshal(t *testing.T) {
 	}
 
 	// Empty packet
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: nil,
-	})
+	raw, err = pck.Unmarshal([]byte{})
 	if raw != nil {
 		t.Fatal("Result should be nil in case of error")
 	}
@@ -34,9 +30,7 @@ func TestOpusPacket_Unmarshal(t *testing.T) {
 	}
 
 	// Normal packet
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90},
-	})
+	raw, err = pck.Unmarshal([]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -55,7 +49,6 @@ func TestOpusPayloader_Payload(t *testing.T) {
 		t.Fatal("Generated payload should be empty")
 	}
 
-	// Note: MTU has no effect
 	// Positive MTU, small payload
 	res = pck.Payload(1, payload)
 	if len(res) != 1 {

--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -2,8 +2,6 @@ package codecs
 
 import (
 	"fmt"
-
-	"github.com/pions/rtp"
 )
 
 // VP8Payloader payloads VP8 packets
@@ -86,11 +84,11 @@ type VP8Packet struct {
 }
 
 // Unmarshal parses the passed byte slice and stores the result in the VP8Packet this method is called upon
-func (p *VP8Packet) Unmarshal(packet *rtp.Packet) ([]byte, error) {
-	if packet == nil {
+func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
+	if payload == nil {
 		return nil, fmt.Errorf("invalid nil packet")
 	}
-	payload := packet.Payload
+
 	payloadLen := len(payload)
 
 	if payloadLen < 4 {

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -3,8 +3,6 @@ package codecs
 import (
 	"fmt"
 	"testing"
-
-	"github.com/pions/rtp"
 )
 
 func TestVP8Packet_Unmarshal(t *testing.T) {
@@ -24,9 +22,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Nil payload
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: nil,
-	})
+	raw, err = pck.Unmarshal([]byte{})
 	if raw != nil {
 		t.Fatal("Result should be nil in case of error")
 	}
@@ -35,9 +31,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Payload smaller than header size
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x00, 0x11, 0x22},
-	})
+	raw, err = pck.Unmarshal([]byte{0x00, 0x11, 0x22})
 	if raw != nil {
 		t.Fatal("Result should be nil in case of error")
 	}
@@ -46,9 +40,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Normal payload
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90},
-	})
+	raw, err = pck.Unmarshal([]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -57,9 +49,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, only X
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x80, 0x00, 0x00, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0x80, 0x00, 0x00, 0x00})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -68,9 +58,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, X and I
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x80, 0x80, 0x00, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0x80, 0x80, 0x00, 0x00})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -79,9 +67,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, X and I, PID 16bits
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x80, 0x80, 0x81, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0x80, 0x80, 0x81, 0x00})
 	if raw != nil {
 		t.Fatal("Result should be nil in case of error")
 	}
@@ -90,9 +76,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, X and L
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x80, 0x40, 0x00, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0x80, 0x40, 0x00, 0x00})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -101,9 +85,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, X and T
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x80, 0x20, 0x00, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0x80, 0x20, 0x00, 0x00})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -112,9 +94,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, X and K
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0x80, 0x10, 0x00, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0x80, 0x10, 0x00, 0x00})
 	if raw == nil {
 		t.Fatal("Result shouldn't be nil in case of success")
 	}
@@ -123,9 +103,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	}
 
 	// Header size, all flags
-	raw, err = pck.Unmarshal(&rtp.Packet{
-		Payload: []byte{0xff, 0xff, 0x00, 0x00},
-	})
+	raw, err = pck.Unmarshal([]byte{0xff, 0xff, 0x00, 0x00})
 	if raw != nil {
 		t.Fatal("Result should be nil in case of error")
 	}

--- a/packet.go
+++ b/packet.go
@@ -211,6 +211,10 @@ func (h *Header) MarshalTo(buf []byte) (n int, err error) {
 	h.PayloadOffset = n
 
 	if h.Extension {
+		if len(h.ExtensionPayload)%4 != 0 {
+			//the payload must be in 32-bit words.
+			return 0, io.ErrShortBuffer
+		}
 		extSize := uint16(len(h.ExtensionPayload) / 4)
 
 		binary.BigEndian.PutUint16(buf[n+0:n+2], h.ExtensionProfile)

--- a/packet_test.go
+++ b/packet_test.go
@@ -82,6 +82,17 @@ func TestExtension(t *testing.T) {
 		t.Fatal("Unmarshal did not error on packet with invalid extension length")
 	}
 
+	p = &Packet{Header: Header{
+		Extension:        true,
+		ExtensionProfile: 3,
+		ExtensionPayload: []byte{0},
+	},
+		Payload: []byte{},
+	}
+	if _, err := p.Marshal(); err == nil {
+		t.Fatal("Marshal did not error on packet with invalid extension length")
+	}
+
 }
 
 func BenchmarkMarshal(b *testing.B) {

--- a/packetizer.go
+++ b/packetizer.go
@@ -13,6 +13,7 @@ type Payloader interface {
 // Packetizer packetizes a payload
 type Packetizer interface {
 	Packetize(payload []byte, samples uint32) []*Packet
+	EnableAbsSendTime(value int)
 }
 
 type packetizer struct {
@@ -23,6 +24,7 @@ type packetizer struct {
 	Sequencer   Sequencer
 	Timestamp   uint32
 	ClockRate   uint32
+	AbsSendTime int //if this is nonzero, then it's the extension number that's applied to http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
 }
 
 // NewPacketizer returns a new instance of a Packetizer for a specific payloader
@@ -39,6 +41,24 @@ func NewPacketizer(mtu int, pt uint8, ssrc uint32, payloader Payloader, sequence
 		Timestamp:   r.Uint32(),
 		ClockRate:   clockRate,
 	}
+}
+
+func (p *packetizer) EnableAbsSendTime(value int) {
+	p.AbsSendTime = value
+}
+
+func toNtpTime(t time.Time) uint64 {
+	var s uint64
+	var f uint64
+	u := uint64(t.UnixNano())
+	s = u / 1e9
+	s += 0x83AA7E80 //offset in seconds between unix epoch and ntp epoch
+	f = u % 1e9
+	f <<= 32
+	f /= 1e9
+	s <<= 32
+
+	return s | f
 }
 
 // Packetize packetizes the payload of an RTP packet and returns one or more RTP packets
@@ -67,6 +87,28 @@ func (p *packetizer) Packetize(payload []byte, samples uint32) []*Packet {
 		}
 	}
 	p.Timestamp += samples
+
+	if p.AbsSendTime != 0 {
+		t := toNtpTime(time.Now()) >> 14
+		//apply http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+		packets[len(payloads)-1].Header.Extension = true
+		packets[len(payloads)-1].ExtensionProfile = 0xBEDE
+		packets[len(payloads)-1].ExtensionPayload = []byte{
+			//the first byte is
+			// 0 1 2 3 4 5 6 7
+			//+-+-+-+-+-+-+-+-+
+			//|  ID   |  len  |
+			//+-+-+-+-+-+-+-+-+
+			//per RFC65285
+			//Len is the number of bytes in the extension - 1
+
+			byte((p.AbsSendTime << 4) | 2),
+			byte(t & 0xFF0000 >> 16),
+			byte(t & 0xFF00 >> 8),
+			byte(t & 0xFF),
+		}
+
+	}
 
 	return packets
 }

--- a/packetizer_test.go
+++ b/packetizer_test.go
@@ -1,0 +1,26 @@
+package rtp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNtpConversion(t *testing.T) {
+	loc := time.FixedZone("UTC-5", -5*60*60)
+
+	tests := []struct {
+		t time.Time
+		n uint64
+	}{
+		{t: time.Date(1985, time.June, 23, 4, 0, 0, 0, loc), n: 0xa0c65b1000000000},
+		{t: time.Date(1999, time.December, 31, 23, 59, 59, 500000, loc), n: 0xbc18084f0020c49b},
+		{t: time.Date(2019, time.March, 27, 13, 39, 30, 8675309, loc), n: 0xe04641e202388b88},
+	}
+
+	for _, in := range tests {
+		out := toNtpTime(in.t)
+		assert.Equal(t, in.n, out)
+	}
+}

--- a/packetizer_test.go
+++ b/packetizer_test.go
@@ -1,9 +1,11 @@
 package rtp
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/pions/rtp/codecs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +25,20 @@ func TestNtpConversion(t *testing.T) {
 		out := toNtpTime(in.t)
 		assert.Equal(t, in.n, out)
 	}
+}
+
+func TestPacketizer(t *testing.T) {
+	multiplepayload := make([]byte, 128)
+	//use the G722 payloader here, because it's very simple and all 0s is valid G722 data.
+	packetizer := NewPacketizer(100, 98, 0x1234ABCD, &codecs.G722Payloader{}, NewRandomSequencer(), 90000)
+	packets := packetizer.Packetize(multiplepayload, 2000)
+
+	if len(packets) != 2 {
+		packetlengths := ""
+		for i := 0; i < len(packets); i++ {
+			packetlengths += fmt.Sprintf("Packet %d length %d\n", i, len(packets[i].Payload))
+		}
+		t.Fatalf("Generated %d packets instead of 2\n%s", len(packets), packetlengths)
+	}
+
 }


### PR DESCRIPTION
abs-send-time adds a wall-clock timestamp to the end of each video frame (when it's enabled)

It seems like libwebrtc likes these extra timestamps, lets enable it.